### PR TITLE
Key item by ID in grid

### DIFF
--- a/src/lib/Grid.svelte
+++ b/src/lib/Grid.svelte
@@ -143,7 +143,7 @@
 	bind:this={gridContainer}
 >
 	{#if _itemSize && _cols && _rows}
-		{#each items as item}
+		{#each items as item (item.id)}
 			<GridItem
 				class={itemClass ?? ''}
 				{item}


### PR DESCRIPTION
When updating the items array, the grid items would change because the grid's each loop was not keyed to the grid items' IDs. This PR simply fixes that.

Thanks for the work on this component!