### PR TITLE
Allow collision option

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@
 
 version: 2
 updates:
-  - package-ecosystem: "yarn" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: 'yarn' # See documentation for possible values
+    directory: '/' # Location of package manifests
     schedule:
-      interval: "weekly"
+      interval: 'weekly'

--- a/src/lib/Grid.svelte
+++ b/src/lib/Grid.svelte
@@ -121,6 +121,8 @@
 	 */
 	export let itemResizerClass: string | undefined = undefined;
 
+	export let collision: boolean | undefined = undefined;
+
 	let _itemSize: ItemSize;
 
 	let _cols: number;
@@ -223,6 +225,7 @@
 					items,
 					readOnly
 				}}
+				{collision}
 				activeClass={itemActiveClass}
 				previewClass={itemPreviewClass}
 				resizerClass={itemResizerClass}

--- a/src/lib/Grid.svelte
+++ b/src/lib/Grid.svelte
@@ -124,7 +124,7 @@
 	/**
 	 * This option allows for collision between grid items, And it also deprecates 'rows' option. (fix to 0)
 	 */
-	export let collision: boolean | undefined = undefined;
+	export let collision = false;
 
 	let _itemSize: ItemSize;
 
@@ -228,9 +228,9 @@
 					bounds,
 					boundsTo: gridContainer,
 					items,
-					readOnly
+					readOnly,
+					collision
 				}}
-				{collision}
 				activeClass={itemActiveClass}
 				previewClass={itemPreviewClass}
 				resizerClass={itemResizerClass}

--- a/src/lib/Grid.svelte
+++ b/src/lib/Grid.svelte
@@ -121,6 +121,9 @@
 	 */
 	export let itemResizerClass: string | undefined = undefined;
 
+	/**
+	 * This option allows for collision between grid items, And it also deprecates 'rows' option. (fix to 0)
+	 */
 	export let collision: boolean | undefined = undefined;
 
 	let _itemSize: ItemSize;
@@ -140,6 +143,8 @@
 	let shouldExpandRows = false;
 
 	let shouldExpandCols = false;
+
+	$: if (collision) rows = 0;
 
 	$: if (typeof cols === 'number') _cols = cols;
 

--- a/src/lib/GridItem.svelte
+++ b/src/lib/GridItem.svelte
@@ -25,8 +25,6 @@
 
 	export let resizerClass: string | undefined = undefined;
 
-	export let collision: boolean | undefined = undefined;
-
 	let active = false;
 
 	let left: number;
@@ -122,7 +120,7 @@
 		left = _left;
 		top = _top;
 
-		if (!collision) {
+		if (!gridParams.collision) {
 			window.scroll({
 				left: left - window.innerWidth / 2,
 				top: top - window.innerHeight / 2,
@@ -132,12 +130,11 @@
 
 		if (
 			Math.abs(left - item.w * gridParams.itemSize.width) > gridParams.itemSize.width / 8 ||
-			Math.abs(left - item.w * gridParams.itemSize.width) > gridParams.itemSize.width / 8 ||
 			Math.abs(top - item.h * gridParams.itemSize.height) > gridParams.itemSize.height / 8
 		) {
 			const { x, y } = snapOnMove(left, top, previewItem, gridParams);
 
-			if (collision) {
+			if (gridParams.collision) {
 				movePreviewWithCollisions(x, y);
 			} else {
 				if (!hasCollisions({ ...previewItem, x, y }, gridParams.items)) {
@@ -255,7 +252,7 @@
 			height = Math.min(height, max.height);
 		}
 
-		if (!collision) {
+		if (!gridParams.collision) {
 			window.scroll({
 				left: left - window.innerWidth / 2,
 				top: top - window.innerHeight / 2,
@@ -268,7 +265,7 @@
 			Math.abs(top - item.h * gridParams.itemSize.height) > gridParams.itemSize.height / 8
 		) {
 			const { w, h } = snapOnResize(width, height, previewItem, gridParams);
-			if (collision) {
+			if (gridParams.collision) {
 				resizePreviewWithCollisions(w, h);
 			} else {
 				if (!hasCollisions({ ...previewItem, w, h }, gridParams.items)) {

--- a/src/lib/GridItem.svelte
+++ b/src/lib/GridItem.svelte
@@ -1,9 +1,7 @@
 <script lang="ts">
 	import { createEventDispatcher } from 'svelte';
-
 	import { coordinate2size, calcPosition, snapOnMove, snapOnResize } from './utils/item';
-	import { hasCollisions } from './utils/grid';
-
+	import { hasCollisions, getCollisions } from './utils/grid';
 	import type { LayoutItem, ItemSize, GridParams, LayoutChangeDetail } from './types';
 
 	type T = $$Generic;
@@ -26,6 +24,8 @@
 	export let previewClass: string | undefined = undefined;
 
 	export let resizerClass: string | undefined = undefined;
+
+	export let collision: boolean | undefined = undefined;
 
 	let active = false;
 
@@ -122,20 +122,71 @@
 		left = _left;
 		top = _top;
 
-		window.scroll({
-			left: left - window.innerWidth / 2,
-			top: top - window.innerHeight / 2,
-			behavior: 'smooth'
-		});
+		if (!collision) {
+			window.scroll({
+				left: left - window.innerWidth / 2,
+				top: top - window.innerHeight / 2,
+				behavior: 'smooth'
+			});
+		}
 
 		if (
+			Math.abs(left - item.w * gridParams.itemSize.width) > gridParams.itemSize.width / 8 ||
 			Math.abs(left - item.w * gridParams.itemSize.width) > gridParams.itemSize.width / 8 ||
 			Math.abs(top - item.h * gridParams.itemSize.height) > gridParams.itemSize.height / 8
 		) {
 			const { x, y } = snapOnMove(left, top, previewItem, gridParams);
-			if (!hasCollisions({ ...previewItem, x, y }, gridParams.items)) {
-				previewItem = { ...previewItem, x, y };
+
+			if (collision) {
+				movePreviewWithCollisions(x, y);
+			} else {
+				if (!hasCollisions({ ...previewItem, x, y }, gridParams.items)) {
+					previewItem = { ...previewItem, x, y };
+					dispatch('itemchange', { item: previewItem as LayoutItem<T> });
+				}
 			}
+		}
+	}
+
+	function movePreviewWithCollisions(x: number, y: number) {
+		let newY = y;
+		const itemsExceptPreview = gridParams.items.filter((item) => item.id != previewItem.id);
+		while (newY >= 0) {
+			const collItems = getCollisions({ ...previewItem, x, y: newY }, gridParams.items);
+			if (collItems.length > 0) {
+				const sortedItems = collItems.sort((a, b) => b.y - a.y);
+				let moved = false;
+				sortedItems.forEach((sortItem) => {
+					//if you want to fix sensitivity of grid, change this statement
+					if (y + previewItem.h / 2 >= sortItem.y + sortItem.h / 2) {
+						moved = true;
+						newY = sortItem.y + sortItem.h;
+						sortedItems.forEach((item) => {
+							if (
+								!hasCollisions({ ...item, y: item.y - previewItem.h }, itemsExceptPreview) &&
+								item.y - previewItem.h >= 0
+							) {
+								item.y -= previewItem.h;
+							}
+						});
+						return false;
+					}
+				});
+				if (!moved) {
+					newY = previewItem.y;
+				}
+				break;
+			}
+			newY--;
+		}
+		if (newY < 0 || y === 0) {
+			newY = 0;
+		}
+		const positionChanged = x != previewItem.x || newY != previewItem.y;
+		previewItem = { ...previewItem, x, y: newY };
+		if (positionChanged) {
+			compressItems();
+			applyPreview();
 		}
 	}
 
@@ -204,20 +255,41 @@
 			height = Math.min(height, max.height);
 		}
 
-		window.scroll({
-			left: left - window.innerWidth / 2,
-			top: top - window.innerHeight / 2,
-			behavior: 'smooth'
-		});
+		if (!collision) {
+			window.scroll({
+				left: left - window.innerWidth / 2,
+				top: top - window.innerHeight / 2,
+				behavior: 'smooth'
+			});
+		}
 
 		if (
 			Math.abs(left - item.w * gridParams.itemSize.width) > gridParams.itemSize.width / 8 ||
 			Math.abs(top - item.h * gridParams.itemSize.height) > gridParams.itemSize.height / 8
 		) {
 			const { w, h } = snapOnResize(width, height, previewItem, gridParams);
-			if (!hasCollisions({ ...previewItem, w, h }, gridParams.items)) {
-				previewItem = { ...previewItem, w, h };
+			if (collision) {
+				resizePreviewWithCollisions(w, h);
+			} else {
+				if (!hasCollisions({ ...previewItem, w, h }, gridParams.items)) {
+					previewItem = { ...previewItem, w, h };
+				}
 			}
+		}
+	}
+
+	function resizePreviewWithCollisions(w: number, h: number) {
+		const sizeChanged = w != previewItem.w || h != previewItem.h;
+		if (sizeChanged) {
+			const hGap = h - previewItem.h;
+			previewItem = { ...previewItem, w, h };
+			applyPreview();
+			const collItems = getCollisions({ ...previewItem, w, h: 9999 }, gridParams.items);
+			collItems.forEach((item) => {
+				item.y += hGap;
+				dispatch('itemchange', { item: item as LayoutItem<T> });
+			});
+			compressItems();
 		}
 	}
 
@@ -226,6 +298,49 @@
 		endInteraction(event);
 		window.removeEventListener('pointermove', resize);
 		window.removeEventListener('pointerup', resizeEnd);
+	}
+
+	function compressItems() {
+		const sortedItems = [...gridParams.items].sort((a, b) => a.y - b.y);
+		sortedItems.reduce(
+			(accItem, currentItem) => {
+				if (currentItem.id === previewItem.id) {
+					//if previewItem do nothing
+				} else if (previewItem.y < currentItem.y + currentItem.h) {
+					//compress items above previewItem
+					const maxY =
+						currentItem.y >= previewItem.y
+							? currentItem.y + previewItem.h + 1
+							: previewItem.y + currentItem.h + 1;
+					let newY = maxY;
+					while (newY >= 0) {
+						if (hasCollisions({ ...currentItem, y: newY }, accItem)) {
+							break;
+						}
+						newY--;
+					}
+					currentItem.y = newY + 1;
+					dispatch('itemchange', { item: currentItem as LayoutItem<T> });
+					accItem.push(currentItem as LayoutItem<T>);
+				} else {
+					//compress items below previewItem
+					let newY = currentItem.y;
+					while (newY >= 0) {
+						if (hasCollisions({ ...currentItem, y: newY }, accItem)) {
+							break;
+						}
+						newY--;
+					}
+					if (newY < currentItem.y && newY > 0) {
+						currentItem.y = newY + 1;
+					}
+					dispatch('itemchange', { item: currentItem as LayoutItem<T> });
+					accItem.push(currentItem as LayoutItem<T>);
+				}
+				return accItem;
+			},
+			[previewItem]
+		);
 	}
 </script>
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -38,6 +38,7 @@ export type GridParams = {
 	boundsTo: HTMLElement;
 	items: LayoutItem[];
 	readOnly: boolean;
+	collision: boolean;
 };
 
 export type LayoutChangeDetail<T = unknown> = {

--- a/src/routes/examples/collision/+page.svelte
+++ b/src/routes/examples/collision/+page.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+	import Grid from '$lib';
+
+	const items = [
+		{ id: '0', x: 0, y: 0, w: 2, h: 5 },
+		{ id: '1', x: 2, y: 2, w: 2, h: 2, min: { w: 1, h: 1 }, max: { w: 3, h: 3 } },
+		{ id: '2', x: 2, y: 0, w: 1, h: 2 },
+		{ id: '3', x: 3, y: 0, w: 2, h: 2 },
+		{ id: '4', x: 4, y: 2, w: 1, h: 3 },
+		{ id: '5', x: 8, y: 0, w: 2, h: 8 },
+		{ id: '6', x: 4, y: 5, w: 1, h: 1 },
+		{ id: '7', x: 2, y: 6, w: 3, h: 2 },
+		{ id: '8', x: 2, y: 4, w: 2, h: 2 }
+	];
+	const itemSize = { height: 100 };
+</script>
+
+<Grid {items} cols={10} {itemSize} collision={true} let:item>
+	<div class="item">{item.id}</div>
+</Grid>
+
+<style>
+	.item {
+		display: grid;
+		place-items: center;
+		background-color: rgb(150, 150, 150);
+		width: 100%;
+		height: 100%;
+	}
+</style>

--- a/tests/unit/item.test.ts
+++ b/tests/unit/item.test.ts
@@ -156,7 +156,11 @@ const gridParams: GridParams = {
 	maxCols: 8,
 	maxRows: 8,
 	items: [],
-	bounds: false
+	bounds: false,
+	//It can be tested on the environment of a browser.
+	boundsTo: new Object() as HTMLElement,
+	readOnly: false,
+	collision: true
 };
 
 describe('🥥 snapOnMove()', () => {


### PR DESCRIPTION
I added an option regarding #16. this option will work as follows.
1. If collision occurs, the position of the preview will be exchanged with that of the collision target.
2. If the position exchange leaves a blank space, all items will be compressed to the top where they can be.
3. It will deprecate "rows" option (fix to 0).
4. I mainly referred to https://jbaysolutions.github.io/vue-grid-layout/guide/01-basic.html