### PR TITLE
Add compress prop (collision)

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,9 +314,9 @@ Make item non-interactive: ✨ [repl](https://svelte.dev/repl/1b3b9b9b9b9b9b9b9b
 
 <!-- set collision = true -->
 
-To enable collisions, set `collision` prop to `true`. Now instead of ignoring collisions, grid will try to move all coliding items to the nearest available position.
+To enable collisions, set the `collision` prop to `true`. Now, instead of ignoring collisions, the grid will relocate all colliding items to the first available space. If necessary, it will also expand the grid vertically to accommodate these items.
 
-> ⚠️ Setting `collision` to `true` will sets `rows` to `0` and force grid to compress items in vertical direction.
+> ⚠️ Setting `collision` to `true` will sets `rows` to `0`.
 
 <!-- repl -->
 
@@ -334,6 +334,34 @@ To enable collisions, set `collision` prop to `true`. Now instead of ignoring co
 </script>
 
 <Grid {items} cols={10} {itemSize} collision={true} let:item>
+	<div class="item">{item.id}</div>
+</Grid>
+```
+
+### Enable Compression
+
+<!-- set compress = true -->
+
+By setting the `compress` prop to `true`, you modify the default behavior of item dragging. In the default state (`compress` set to `false`), items can be dragged freely and are moved to the first available position when a collision occurs. However, when `compress` is `true`, the grid will compress items vertically towards the top into any available space instead.
+
+> ⚠️ The `compress` prop only takes effect when `collision` is set to `true`.
+
+<!-- repl -->
+
+✨ [repl](https://svelte.dev/repl/065b1b4d674740d6a73b49c863d60cda?version%253D4.0.4)
+
+```svelte
+<script lang="ts">
+	import Grid from '$lib';
+
+	const items = [
+		{ id: '0', x: 0, y: 0, w: 2, h: 5 },
+		{ id: '1', x: 2, y: 2, w: 2, h: 2 }
+	];
+	const itemSize = { height: 100 };
+</script>
+
+<Grid {items} cols={10} {itemSize} collision={true} compress={true} let:item>
 	<div class="item">{item.id}</div>
 </Grid>
 ```

--- a/src/lib/Grid.svelte
+++ b/src/lib/Grid.svelte
@@ -126,6 +126,11 @@
 	 */
 	export let collision = false;
 
+	/**
+	 * This option allows for vertical compression grid items when collision is enabled.
+	 */
+	export let compress = false;
+
 	let _itemSize: ItemSize;
 
 	let _cols: number;
@@ -229,7 +234,8 @@
 					boundsTo: gridContainer,
 					items,
 					readOnly,
-					collision
+					collision,
+					compress
 				}}
 				activeClass={itemActiveClass}
 				previewClass={itemPreviewClass}

--- a/src/lib/GridItem.svelte
+++ b/src/lib/GridItem.svelte
@@ -1,7 +1,12 @@
 <script lang="ts">
 	import { createEventDispatcher } from 'svelte';
 	import { coordinate2size, calcPosition, snapOnMove, snapOnResize } from './utils/item';
-	import { hasCollisions, getCollisions } from './utils/grid';
+	import {
+		hasCollisions,
+		getCollisions,
+		getAvailablePosition,
+		getGridDimensions
+	} from './utils/grid';
 	import type { LayoutItem, ItemSize, GridParams, LayoutChangeDetail } from './types';
 
 	type T = $$Generic;
@@ -47,6 +52,10 @@
 	}
 
 	let previewItem: LayoutItem<T> = item;
+
+	$: if (!active && item) {
+		previewItem = item;
+	}
 
 	$: previewItem, dispatch('previewchange', { item: previewItem });
 
@@ -145,7 +154,49 @@
 		}
 	}
 
-	function movePreviewWithCollisions(x: number, y: number) {
+	function updateCollItemPositionWithoutCompress(collItem: LayoutItem, items: LayoutItem[]) {
+		const newPosition = getAvailablePosition(collItem, items, gridParams.maxCols);
+		if (newPosition) {
+			const { x, y } = newPosition;
+			collItem.x = x;
+			collItem.y = y;
+		} else {
+			// no available space
+			const { rows } = getGridDimensions(items);
+			collItem.x = 0;
+			collItem.y = rows;
+		}
+		dispatch('itemchange', { item: collItem as LayoutItem<T> });
+	}
+
+	function handleCollisionsForPreviewItemWithoutCompress(newAttributes: {
+		x?: number;
+		y?: number;
+		w?: number;
+		h?: number;
+	}) {
+		const itemsExceptPreview = gridParams.items.filter((item) => item.id != previewItem.id);
+		const collItems = getCollisions({ ...previewItem, ...newAttributes }, itemsExceptPreview);
+
+		collItems.forEach((collItem: LayoutItem) => {
+			const itemsExceptCollItem = gridParams.items.filter((item) => item.id != collItem.id);
+			const items = [
+				...itemsExceptCollItem.filter((item) => item.id != previewItem.id),
+				{ ...previewItem, ...newAttributes }
+			];
+			updateCollItemPositionWithoutCompress(collItem, items);
+		});
+
+		previewItem = { ...previewItem, ...newAttributes };
+		dispatch('itemchange', { item: previewItem as LayoutItem<T> });
+		applyPreview();
+	}
+
+	function movePreviewWithCollisionsWithoutCompress(x: number, y: number) {
+		handleCollisionsForPreviewItemWithoutCompress({ x, y });
+	}
+
+	function movePreviewWithCollisionsWithCompress(x: number, y: number) {
 		let newY = y;
 		const itemsExceptPreview = gridParams.items.filter((item) => item.id != previewItem.id);
 		while (newY >= 0) {
@@ -184,6 +235,14 @@
 		if (positionChanged) {
 			compressItems();
 			applyPreview();
+		}
+	}
+
+	function movePreviewWithCollisions(x: number, y: number) {
+		if (gridParams.compress) {
+			movePreviewWithCollisionsWithCompress(x, y);
+		} else {
+			movePreviewWithCollisionsWithoutCompress(x, y);
 		}
 	}
 
@@ -275,7 +334,11 @@
 		}
 	}
 
-	function resizePreviewWithCollisions(w: number, h: number) {
+	function resizePreviewWithCollisionsWithoutCompress(w: number, h: number) {
+		handleCollisionsForPreviewItemWithoutCompress({ w, h });
+	}
+
+	function resizePreviewWithCollisionsWithCompress(w: number, h: number) {
 		const sizeChanged = w != previewItem.w || h != previewItem.h;
 		if (sizeChanged) {
 			const hGap = h - previewItem.h;
@@ -287,6 +350,14 @@
 				dispatch('itemchange', { item: item as LayoutItem<T> });
 			});
 			compressItems();
+		}
+	}
+
+	function resizePreviewWithCollisions(w: number, h: number) {
+		if (gridParams.compress) {
+			resizePreviewWithCollisionsWithCompress(w, h);
+		} else {
+			resizePreviewWithCollisionsWithoutCompress(w, h);
 		}
 	}
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -39,6 +39,7 @@ export type GridParams = {
 	items: LayoutItem[];
 	readOnly: boolean;
 	collision: boolean;
+	compress: boolean;
 };
 
 export type LayoutChangeDetail<T = unknown> = {

--- a/src/lib/utils/grid.ts
+++ b/src/lib/utils/grid.ts
@@ -24,3 +24,26 @@ export function getGridDimensions(items: LayoutItem[]): GridDimensions {
 
 	return { cols, rows };
 }
+
+export function getAvailablePosition(
+	currentItem: LayoutItem,
+	items: LayoutItem[],
+	maxCols: number
+): { x: number; y: number } | null {
+	const { cols, rows } = getGridDimensions(items);
+
+	if (maxCols === 0 || maxCols === Infinity) maxCols = cols;
+
+	for (let y = 0; y <= rows - currentItem.h; y++) {
+		for (let x = 0; x <= maxCols - currentItem.w; x++) {
+			const item = { ...currentItem, x, y };
+
+			if (!hasCollisions(item, items)) {
+				const newPosition = { x, y };
+				return newPosition;
+			}
+		}
+	}
+
+	return null;
+}

--- a/src/routes/examples/collision/+page.svelte
+++ b/src/routes/examples/collision/+page.svelte
@@ -15,7 +15,7 @@
 	const itemSize = { height: 100 };
 </script>
 
-<Grid {items} cols={10} {itemSize} collision={true} let:item>
+<Grid {items} cols={10} {itemSize} collision={true} compress={false} let:item>
 	<div class="item">{item.id}</div>
 </Grid>
 

--- a/tests/unit/item.test.ts
+++ b/tests/unit/item.test.ts
@@ -160,7 +160,8 @@ const gridParams: GridParams = {
 	//It can be tested on the environment of a browser.
 	boundsTo: new Object() as HTMLElement,
 	readOnly: false,
-	collision: true
+	collision: true,
+	compress: true
 };
 
 describe('🥥 snapOnMove()', () => {


### PR DESCRIPTION
Added compress prop (ref #32) and logic to handle if grid should vertical compress or not when collision is active. If `compress = false` then:

- Enables free item movement on the grid.
- Collision between items leads to relocation of the collided item.
- The relocation is to the first available space.
- Grid can dynamically expand on the y-axis if no space is available.
- Expansion accommodates the relocated item in a new position.

Additionally, a bug has been fixed where the previewItem of items, which had previously collided and been moved, was not updating correctly. This issue occasionally caused certain items to unexpectedly jump to a different position when clicked.