### PR TITLE
Refactor collision prop new API

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,11 @@ pnpm add svelte-grid-extended
 | cols     | Grid columns count. If set to 0, grid will grow infinitly. Must be >= 0.           | number                              | 0        |
 | rows     | Grid rows count. If set to 0, grid will grow infinitly. Must be >= 0.              | number                              | 0        |
 | itemSize | Size of the grid item. If not set, grid will calculate it based on container size. | { width?: number, height?: number } | {}       |
-| items    | Array of grid items.                                                               | [Layout\<T\>](#layout-type)         | requried |
+| items    | Array of grid items.                                                               | [Layout\<T\>](#layout-type)         | required |
 | gap      | Gap between grid items.                                                            | number                              | 10       |
 | bounds   | Should grid items be bounded by the grid container.                                | boolean                             | false    |
 | readonly | If true disables interaction with grid items.                                      | boolean                             | false    |
+| collision | Collision behavior of grid items. Can be `none`, `push`, or `compress`.                                      | string                             | `none`    |
 
 > ⚠️ if `cols` or/and `rows` are set to 0, `itemSize.width` or/and `itemSize.height` must be setted.
 
@@ -50,11 +51,11 @@ pnpm add svelte-grid-extended
 
 | prop      | description                                                         | type    | default   |
 | --------- | ------------------------------------------------------------------- | ------- | --------- |
-| id        | Unique id of the item. Used to compare items during collision tests | string  | requried  |
-| x         | X position of the item in grid units.                               | number  | requried  |
-| y         | Y position of the item in grid units.                               | number  | requried  |
-| w         | Width of the item in grid units.                                    | number  | requried  |
-| h         | Height of the item in grid units.                                   | number  | requried  |
+| id        | Unique id of the item. Used to compare items during collision tests | string  | required  |
+| x         | X position of the item in grid units.                               | number  | required  |
+| y         | Y position of the item in grid units.                               | number  | required  |
+| w         | Width of the item in grid units.                                    | number  | required  |
+| h         | Height of the item in grid units.                                   | number  | required  |
 | movable   | If true, item can be moved by user.                                 | boolean | true      |
 | resizable | If true, item can be resized by user.                               | boolean | true      |
 | data      | Custom attributes. 🦌                                               | T       | undefined |
@@ -123,11 +124,24 @@ Grid emits the following events:
 
 ## Usage
 
-- [Basic](#basic)
-- [Static grid](#static-grid)
-- [Grid without bounds](#grid-without-bounds)
-- [Styling](#styling)
-- [Disable interactions](#disable-interactions)
+- [svelte-grid-extended](#svelte-grid-extended)
+	- [Description](#description)
+	- [Installation](#installation)
+	- [Props](#props)
+		- [Main props](#main-props)
+		- [Layout](#layout)
+		- [Style related props:](#style-related-props)
+	- [Events](#events)
+	- [Usage](#usage)
+		- [Basic](#basic)
+		- [Static grid](#static-grid)
+		- [Grid without bounds](#grid-without-bounds)
+		- [Styling](#styling)
+		- [Disable interactions](#disable-interactions)
+		- [Collision Behavior](#collision-behavior)
+			- [None](#none)
+			- [Push](#push)
+			- [Compress](#compress)
 
 ### Basic
 
@@ -307,3 +321,100 @@ Make item non-interactive: ✨ [repl](https://svelte.dev/repl/1b3b9b9b9b9b9b9b9b
 	<div>Content</div>
 </Grid>
 ```
+
+### Collision Behavior
+
+The `collision` prop controls how the grid handles collisions. There are three available options: `none`, `push`, and `compress`.
+
+#### None
+
+Setting `collision` prop to `none` will ignore any collisions. This is the default behavior.
+
+✨ [repl](https://svelte.dev/repl/c549a05c30b84793b2bab156f49bedd3?version=4.1.1)
+
+```svelte
+<script lang="ts">
+	import Grid, { GridItem } from 'svelte-grid-extended';
+
+	const items = [
+		{ id: '0', x: 0, y: 0, w: 2, h: 5 },
+		{ id: '1', x: 2, y: 2, w: 2, h: 2 },
+		{ id: '2', x: 2, y: 0, w: 1, h: 2 },
+		{ id: '3', x: 3, y: 0, w: 2, h: 2 },
+		{ id: '4', x: 4, y: 2, w: 1, h: 3 },
+		{ id: '5', x: 8, y: 0, w: 2, h: 8 }
+	];
+	
+	const itemSize = { height: 40 };
+</script>
+
+<Grid {itemSize} cols={10} collision="none">
+	{#each items as item}
+		<GridItem x={item.x} y={item.y} w={item.w} h={item.h}>
+			<div class="item">{item.id}</div>
+		</GridItem>
+	{/each}
+</Grid>
+```
+
+#### Push
+Setting `collision` prop to `push` will cause grid items to move to the first available space when colliding. The grid will grow vertically as needed to accommodate all items.
+
+✨ [repl](https://svelte.dev/repl/36abb5e5be6f4b0ebe637b2676ccf606?version=4.1.1)
+
+```svelte
+<script lang="ts">
+	import Grid, { GridItem } from 'svelte-grid-extended';
+
+	const items = [
+		{ id: '0', x: 0, y: 0, w: 2, h: 5 },
+		{ id: '1', x: 2, y: 2, w: 2, h: 2 },
+		{ id: '2', x: 2, y: 0, w: 1, h: 2 },
+		{ id: '3', x: 3, y: 0, w: 2, h: 2 },
+		{ id: '4', x: 4, y: 2, w: 1, h: 3 },
+		{ id: '5', x: 8, y: 0, w: 2, h: 8 }
+	];
+	
+	const itemSize = { height: 40 };
+</script>
+
+<Grid {itemSize} cols={10} collision="push">
+	{#each items as item}
+		<GridItem x={item.x} y={item.y} w={item.w} h={item.h}>
+			<div class="item">{item.id}</div>
+		</GridItem>
+	{/each}
+</Grid>
+```
+
+#### Compress
+Setting `collision` prop to `compress` will compress items vertically towards the top into any available space when colliding. The grid will grow vertically as needed to accommodate all items.
+
+✨ [repl](https://svelte.dev/repl/86cff54f2efa437285c3245ecb713702?version=4.1.1)
+
+```svelte
+<script lang="ts">
+	import Grid, { GridItem } from 'svelte-grid-extended';
+
+	const items = [
+		{ id: '0', x: 0, y: 0, w: 2, h: 5 },
+		{ id: '1', x: 2, y: 2, w: 2, h: 2 },
+		{ id: '2', x: 2, y: 0, w: 1, h: 2 },
+		{ id: '3', x: 3, y: 0, w: 2, h: 2 },
+		{ id: '4', x: 4, y: 2, w: 1, h: 3 },
+		{ id: '5', x: 8, y: 0, w: 2, h: 8 }
+	];
+	
+	const itemSize = { height: 40 };
+</script>
+
+<Grid {itemSize} cols={10} collision="compress">
+	{#each items as item}
+		<GridItem x={item.x} y={item.y} w={item.w} h={item.h}>
+			<div class="item">{item.id}</div>
+		</GridItem>
+	{/each}
+</Grid>
+```
+
+> ⚠️ Setting `collision` to `push` or `compress` will set `rows` to `0` so `ItemSize.height` must be setted.

--- a/src/lib/Grid.svelte
+++ b/src/lib/Grid.svelte
@@ -24,7 +24,8 @@
 		GridSize,
 		LayoutItem,
 		LayoutChangeDetail,
-		GridParams
+		GridParams,
+		Collision
 	} from './types';
 	import { writable, type Readable, type Writable } from 'svelte/store';
 
@@ -109,6 +110,11 @@
 
 	export { classes as class };
 
+	/**
+	 * This option set the collision strategy between grid items. If is not 'none' then it sets 'rows' option to 0.
+	 */
+	export let collision: Collision = 'none';
+
 	let _cols: number;
 
 	let _rows: number;
@@ -150,10 +156,14 @@
 		maxRows = shouldExpandRows ? Infinity : _rows;
 	}
 
+	$: if (collision !== 'none') {
+		rows = 0;
+	}
+
 	/**
-	 * Force the grid to update its dimensions. By default called when any of the grid items changes.
+	 * Force the grid to update. By default called when any of the grid items changes.
 	 */
-	function updateGridDimensions() {
+	function updateGrid() {
 		items = items;
 	}
 
@@ -207,9 +217,10 @@
 		bounds,
 		readOnly,
 		debug,
+		collision,
 		registerItem,
 		unregisterItem,
-		updateGridDimensions
+		updateGrid
 	});
 
 	$: gridSettings.update((settings) => ({
@@ -222,7 +233,8 @@
 		items,
 		bounds,
 		readOnly,
-		debug
+		debug,
+		collision
 	}));
 
 	setContext(GRID_CONTEXT_NAME, gridSettings);

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -51,11 +51,14 @@ export type GridParams = {
 	items: Record<string, LayoutItem>;
 	readOnly: boolean;
 	debug: boolean;
+	collision: Collision;
 	registerItem: (item: LayoutItem) => void;
 	unregisterItem: (item: LayoutItem) => void;
-	updateGridDimensions: () => void;
+	updateGrid: () => void;
 };
 
 export type LayoutChangeDetail = {
 	item: LayoutItem;
 };
+
+export type Collision = 'none' | 'push' | 'compress';

--- a/src/lib/utils/grid.ts
+++ b/src/lib/utils/grid.ts
@@ -29,3 +29,31 @@ export function getGridDimensions(items: LayoutItem[]): GridDimensions {
 
 	return { cols, rows };
 }
+
+export function getAvailablePosition(
+	currentItem: LayoutItem,
+	items: LayoutItem[],
+	maxCols: number,
+	maxRows: number
+): { x: number; y: number } | null {
+	let { cols, rows } = getGridDimensions(items);
+
+	if (maxCols < Infinity) cols = maxCols;
+	if (maxRows < Infinity) rows = maxRows;
+
+	for (let y = 0; y <= rows - currentItem.h; y++) {
+		for (let x = 0; x <= cols - currentItem.w; x++) {
+			const item = { ...currentItem, x, y };
+
+			if (!hasCollisions(item, items)) {
+				const newPosition = { x, y };
+				return newPosition;
+			}
+		}
+	}
+
+	if (maxRows === Infinity) return { x: 0, y: rows };
+	if (maxCols === Infinity) return { x: cols, y: 0 };
+
+	return null;
+}

--- a/src/routes/examples/collision-compress/+page.svelte
+++ b/src/routes/examples/collision-compress/+page.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+	import Grid, { GridItem } from '$lib';
+
+	const items = [
+		{ id: '0', x: 0, y: 0, w: 2, h: 5 },
+		{ id: '1', x: 2, y: 2, w: 2, h: 2 },
+		{ id: '2', x: 2, y: 0, w: 1, h: 2 },
+		{ id: '3', x: 3, y: 0, w: 2, h: 2 },
+		{ id: '4', x: 4, y: 2, w: 1, h: 3 },
+		{ id: '5', x: 8, y: 0, w: 2, h: 8 },
+		{ id: '6', x: 4, y: 5, w: 1, h: 1 },
+		{ id: '7', x: 2, y: 6, w: 3, h: 2 },
+		{ id: '8', x: 2, y: 4, w: 2, h: 2 }
+	];
+
+	const itemSize = { height: 40 };
+</script>
+
+<Grid {itemSize} cols={10} collision="compress">
+	{#each items as item}
+		<GridItem x={item.x} y={item.y} w={item.w} h={item.h}>
+			<div class="item">{item.id}</div>
+		</GridItem>
+	{/each}
+</Grid>
+
+<style>
+	.item {
+		display: grid;
+		place-items: center;
+		background-color: rgb(150, 150, 150);
+		width: 100%;
+		height: 100%;
+	}
+</style>

--- a/src/routes/examples/collision-push/+page.svelte
+++ b/src/routes/examples/collision-push/+page.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+	import Grid, { GridItem } from '$lib';
+
+	const items = [
+		{ id: '0', x: 0, y: 0, w: 2, h: 5 },
+		{ id: '1', x: 2, y: 2, w: 2, h: 2 },
+		{ id: '2', x: 2, y: 0, w: 1, h: 2 },
+		{ id: '3', x: 3, y: 0, w: 2, h: 2 },
+		{ id: '4', x: 4, y: 2, w: 1, h: 3 },
+		{ id: '5', x: 8, y: 0, w: 2, h: 8 },
+		{ id: '6', x: 4, y: 5, w: 1, h: 1 },
+		{ id: '7', x: 2, y: 6, w: 3, h: 2 },
+		{ id: '8', x: 2, y: 4, w: 2, h: 2 }
+	];
+
+	const itemSize = { height: 40 };
+</script>
+
+<Grid {itemSize} cols={10} collision="push">
+	{#each items as item}
+		<GridItem x={item.x} y={item.y} w={item.w} h={item.h}>
+			<div class="item">{item.id}</div>
+		</GridItem>
+	{/each}
+</Grid>
+
+<style>
+	.item {
+		display: grid;
+		place-items: center;
+		background-color: rgb(150, 150, 150);
+		width: 100%;
+		height: 100%;
+	}
+</style>

--- a/tests/unit/grid.test.ts
+++ b/tests/unit/grid.test.ts
@@ -4,7 +4,8 @@ import {
 	getCollisions,
 	getGridDimensions,
 	hasCollisions,
-	isItemColliding
+	isItemColliding,
+	getAvailablePosition
 } from '../../src/lib/utils/grid';
 
 import type { LayoutItem } from '../../src/lib/types';
@@ -18,14 +19,14 @@ import type { LayoutItem } from '../../src/lib/types';
  * Where ~ is empty spot
  */
 const items: LayoutItem[] = [
-	{ id: '0', x: 0, y: 0, w: 1, h: 1 },
-	{ id: '1', x: 1, y: 0, w: 1, h: 1 },
-	{ id: '2', x: 2, y: 0, w: 1, h: 1 },
-	{ id: '3', x: 3, y: 0, w: 1, h: 1 },
-	{ id: '4', x: 0, y: 1, w: 1, h: 1 },
-	{ id: '5', x: 1, y: 1, w: 3, h: 2 },
-	{ id: '6', x: 0, y: 2, w: 1, h: 1 },
-	{ id: '7', x: 0, y: 3, w: 1, h: 1 }
+	{ id: '0', x: 0, y: 0, w: 1, h: 1, movable: true, resizable: true },
+	{ id: '1', x: 1, y: 0, w: 1, h: 1, movable: true, resizable: true },
+	{ id: '2', x: 2, y: 0, w: 1, h: 1, movable: true, resizable: true },
+	{ id: '3', x: 3, y: 0, w: 1, h: 1, movable: true, resizable: true },
+	{ id: '4', x: 0, y: 1, w: 1, h: 1, movable: true, resizable: true },
+	{ id: '5', x: 1, y: 1, w: 3, h: 2, movable: true, resizable: true },
+	{ id: '6', x: 0, y: 2, w: 1, h: 1, movable: true, resizable: true },
+	{ id: '7', x: 0, y: 3, w: 1, h: 1, movable: true, resizable: true }
 ];
 
 describe('🎏 isItemColliding()', () => {
@@ -40,33 +41,43 @@ describe('🎏 isItemColliding()', () => {
 
 	test.each([
 		[
-			{ id: '5', x: 1, y: 1, w: 3, h: 2 },
-			{ id: '1', x: 1, y: 1, w: 1, h: 1 }
+			{ id: '5', x: 1, y: 1, w: 3, h: 2, movable: true, resizable: true },
+			{ id: '1', x: 1, y: 1, w: 1, h: 1, movable: true, resizable: true }
 		],
 		[
-			{ id: '5', x: 1, y: 1, w: 3, h: 2 },
-			{ id: '1', x: 2, y: 1, w: 1, h: 1 }
+			{ id: '5', x: 1, y: 1, w: 3, h: 2, movable: true, resizable: true },
+			{ id: '1', x: 2, y: 1, w: 1, h: 1, movable: true, resizable: true }
 		],
 		[
-			{ id: '5', x: 1, y: 1, w: 3, h: 2 },
-			{ id: '1', x: 1, y: 2, w: 1, h: 1 }
+			{ id: '5', x: 1, y: 1, w: 3, h: 2, movable: true, resizable: true },
+			{ id: '1', x: 1, y: 2, w: 1, h: 1, movable: true, resizable: true }
 		],
 		[
-			{ id: '5', x: 1, y: 1, w: 3, h: 2 },
-			{ id: '1', x: 2, y: 2, w: 1, h: 1 }
+			{ id: '5', x: 1, y: 1, w: 3, h: 2, movable: true, resizable: true },
+			{ id: '1', x: 2, y: 2, w: 1, h: 1, movable: true, resizable: true }
 		]
 	])("should collide when item is within another item's bounding box", (item1, item2) => {
 		expect(isItemColliding(item1, item2)).toBe(true);
 	});
 
 	test.each(items)("should not collide when item within another item's bounding box", (item) => {
-		const itemTopLeft = { id: 'itemTopLeft', x: item.x - item.w, y: item.y - item.h, w: 1, h: 1 };
+		const itemTopLeft = {
+			id: 'itemTopLeft',
+			x: item.x - item.w,
+			y: item.y - item.h,
+			w: 1,
+			h: 1,
+			movable: true,
+			resizable: true
+		};
 		const itemBottomRight = {
 			id: 'itemBottomRight',
 			x: item.x + item.w,
 			y: item.y + item.h,
 			w: 1,
-			h: 1
+			h: 1,
+			movable: true,
+			resizable: true
 		};
 		expect(isItemColliding(item, itemTopLeft)).toBe(false);
 		expect(isItemColliding(item, itemBottomRight)).toBe(false);
@@ -75,19 +86,19 @@ describe('🎏 isItemColliding()', () => {
 
 describe('🎐 hasCollisions()', () => {
 	test.each([
-		{ id: '8', x: 1, y: 3, w: 1, h: 1 },
-		{ id: '8', x: 2, y: 3, w: 1, h: 1 },
-		{ id: '8', x: 3, y: 3, w: 1, h: 1 },
-		{ id: '8', x: 1, y: 3, w: 2, h: 1 }
+		{ id: '8', x: 1, y: 3, w: 1, h: 1, movable: true, resizable: true },
+		{ id: '8', x: 2, y: 3, w: 1, h: 1, movable: true, resizable: true },
+		{ id: '8', x: 3, y: 3, w: 1, h: 1, movable: true, resizable: true },
+		{ id: '8', x: 1, y: 3, w: 2, h: 1, movable: true, resizable: true }
 	])('should not have collisions', (item) => {
 		expect(hasCollisions(item, items)).toBe(false);
 	});
 
 	test.each([
-		{ id: '8', x: 0, y: 0, w: 1, h: 1 },
-		{ id: '8', x: 0, y: 1, w: 1, h: 1 },
-		{ id: '8', x: 1, y: 0, w: 1, h: 1 },
-		{ id: '8', x: 1, y: 1, w: 1, h: 1 }
+		{ id: '8', x: 0, y: 0, w: 1, h: 1, movable: true, resizable: true },
+		{ id: '8', x: 0, y: 1, w: 1, h: 1, movable: true, resizable: true },
+		{ id: '8', x: 1, y: 0, w: 1, h: 1, movable: true, resizable: true },
+		{ id: '8', x: 1, y: 1, w: 1, h: 1, movable: true, resizable: true }
 	])('should have collision', (item) => {
 		expect(hasCollisions(item, items)).toBe(true);
 	});
@@ -95,11 +106,11 @@ describe('🎐 hasCollisions()', () => {
 
 describe('🎑 getCollisions()', () => {
 	test.each([
-		[{ id: '8', x: 0, y: 0, w: 1, h: 1 }, 1],
-		[{ id: '8', x: 0, y: 0, w: 2, h: 1 }, 2],
-		[{ id: '8', x: 0, y: 0, w: 2, h: 2 }, 4],
-		[{ id: '8', x: 0, y: 0, w: 3, h: 3 }, 6],
-		[{ id: '8', x: 0, y: 0, w: 4, h: 4 }, 8]
+		[{ id: '8', x: 0, y: 0, w: 1, h: 1, movable: true, resizable: true }, 1],
+		[{ id: '8', x: 0, y: 0, w: 2, h: 1, movable: true, resizable: true }, 2],
+		[{ id: '8', x: 0, y: 0, w: 2, h: 2, movable: true, resizable: true }, 4],
+		[{ id: '8', x: 0, y: 0, w: 3, h: 3, movable: true, resizable: true }, 6],
+		[{ id: '8', x: 0, y: 0, w: 4, h: 4, movable: true, resizable: true }, 8]
 	])('should have collisions', (item, expected) => {
 		expect(getCollisions(item, items).length).toBe(expected);
 	});
@@ -110,5 +121,42 @@ describe('🍦 getGridDimensions()', () => {
 		const { cols, rows } = getGridDimensions(items);
 		expect(cols).toBe(4);
 		expect(rows).toBe(4);
+	});
+});
+
+describe('🍨 getAvailablePosition()', () => {
+	test.each([
+		{
+			item: { id: '8', x: 0, y: 0, w: 1, h: 1, movable: true, resizable: true },
+			expected: { x: 4, y: 0 },
+			maxCols: 5,
+			maxRows: Infinity
+		},
+		{
+			item: { id: '8', x: 0, y: 0, w: 1, h: 1, movable: true, resizable: true },
+			expected: { x: 1, y: 3 },
+			maxCols: Infinity,
+			maxRows: Infinity
+		},
+		{
+			item: { id: '8', x: 0, y: 0, w: 4, h: 4, movable: true, resizable: true },
+			expected: { x: 0, y: 4 },
+			maxCols: 5,
+			maxRows: Infinity
+		},
+		{
+			item: { id: '8', x: 0, y: 0, w: 4, h: 4, movable: true, resizable: true },
+			expected: { x: 4, y: 0 },
+			maxCols: Infinity,
+			maxRows: 5
+		},
+		{
+			item: { id: '8', x: 0, y: 0, w: 4, h: 4, movable: true, resizable: true },
+			expected: null,
+			maxCols: 5,
+			maxRows: 5
+		}
+	])('should return available position', ({ item, expected, maxCols, maxRows }) => {
+		expect(getAvailablePosition(item, items, maxCols, maxRows)).toEqual(expected);
 	});
 });

--- a/tests/unit/item.test.ts
+++ b/tests/unit/item.test.ts
@@ -153,15 +153,24 @@ describe('🥝 clamp()', () => {
 const gridParams: GridParams = {
 	itemSize: { width: 100, height: 100 },
 	gap: 0,
+	cols: 8,
+	rows: 8,
 	maxCols: 8,
 	maxRows: 8,
-	items: [],
-	bounds: false
+	items: {},
+	bounds: false,
+	boundsTo: new Object() as HTMLElement,
+	debug: false,
+	readOnly: false,
+	collision: 'none',
+	registerItem: () => {},
+	unregisterItem: () => {},
+	updateGrid: () => {}
 };
 
 describe('🥥 snapOnMove()', () => {
-	const item1x1: LayoutItem = { id: '0', x: 0, y: 0, w: 1, h: 1 };
-	const item4x4: LayoutItem = { id: '0', x: 0, y: 0, w: 4, h: 4 };
+	const item1x1: LayoutItem = { id: '0', x: 0, y: 0, w: 1, h: 1, movable: true, resizable: true };
+	const item4x4: LayoutItem = { id: '0', x: 0, y: 0, w: 4, h: 4, movable: true, resizable: true };
 
 	test.each([
 		[0, 0, item1x1, gridParams, { x: 0, y: 0 }],
@@ -213,8 +222,8 @@ describe('🥥 snapOnMove()', () => {
 });
 
 describe('🍍 snapOnResize()', () => {
-	const itemX1Y1: LayoutItem = { id: '0', x: 1, y: 1, w: 1, h: 1 };
-	const itemX4Y4: LayoutItem = { id: '0', x: 4, y: 4, w: 1, h: 1 };
+	const itemX1Y1: LayoutItem = { id: '0', x: 1, y: 1, w: 1, h: 1, movable: true, resizable: true };
+	const itemX4Y4: LayoutItem = { id: '0', x: 4, y: 4, w: 1, h: 1, movable: true, resizable: true };
 
 	test.each([
 		[100, 100, itemX1Y1, gridParams, { w: 1, h: 1 }],
@@ -266,7 +275,7 @@ describe('🍍 snapOnResize()', () => {
 });
 
 describe('🫑 calcPosition()', () => {
-	const item: LayoutItem = { id: '0', x: 1, y: 1, w: 1, h: 1 };
+	const item: LayoutItem = { id: '0', x: 1, y: 1, w: 1, h: 1, movable: true, resizable: true };
 	const itemSize: ItemSize = { width: 100, height: 100 };
 	const gap = 0;
 


### PR DESCRIPTION
Changed current collision prop to be compatible with new api (#27 #35 #23)

Also (since we are still pre 1.0) this PR optimizes collision handling by merging the `compress` and `collision` props into a single `collision` prop.

The refactored `collision` prop provides three behaviors:

- `none` (default): Grid items collisions are ignored. Current `collision={false} compress={false}`
- `push`: On collision, items move to the first available space. Current `collision={true} compress={false}`
- `compress`: On collision, items compress vertically towards available space. Current `collision={true} compress={true}`

This enhancement simplifies the API, improves intuitiveness, and also makes the API more extensible, allowing for future collision behaviors to be added without major structural changes.

