### PR TITLE
Fix grid item width and height calculation for correct spacing

### DIFF
--- a/src/lib/Grid.svelte
+++ b/src/lib/Grid.svelte
@@ -206,8 +206,8 @@
 			shouldExpandRows = _rows === 0;
 
 			$gridSettings.itemSize = {
-				width: itemSize.width ?? (width - (gap + 1) * _cols) / _cols,
-				height: itemSize.height ?? (height - (gap + 1) * _rows) / _rows
+				width: itemSize.width ?? (width - (_cols + 1) * gap) / _cols,
+				height: itemSize.height ?? (height - (_rows + 1) * gap) / _rows
 			};
 		});
 


### PR DESCRIPTION
This PR 
- Addresses a bug in the library where the calculation of grid item width and height results in extra space on the right and bottom sides of the grid when the grid cols or grid rows values differ from the grid gap value. 
- Closes #81 

### Problem:
The current formula used to calculate grid item width and height is incorrect:
* Width: (width - (gap + 1) times cols) / cols
* Height: (height - (gap + 1) times rows) / rows
This formula mistakenly assumes the total width or height occupied by gaps is (gap + 1) times cols for width and (gap + 1) times rows for height, which is incorrect. The correct formula should consider the total number of gaps, which is (cols + 1) for width and (rows + 1) for height. 

### Solution:
The formulas have been updated to correctly calculate the width and height of grid items:
* Corrected Width: (width - (cols + 1) times gap) / cols
* Corrected Height: (height - (rows + 1) times gap) / rows