### PR TITLE
Stop propagation of pointer down event

### DIFF
--- a/src/lib/GridItem.svelte
+++ b/src/lib/GridItem.svelte
@@ -197,6 +197,7 @@
 
 	function moveStart(event: PointerEvent) {
 		if (event.button !== 0) return;
+		event.stopPropagation();
 		initInteraction(event);
 		initialPosition = { left, top };
 		pointerShift = { left: event.pageX - left, top: event.pageY - top };


### PR DESCRIPTION
This PR calls stopPropagation() on the pointerdown event on the move handle, same way as it's done with the resize event. This way we can have nested grids and move items inside the inner grid without the outer grid being affected.